### PR TITLE
fix hxd.res.Image.ImageInfo being used instead of haxe.ui.assets.ImageInfo

### DIFF
--- a/haxe/ui/backend/AssetsImpl.hx
+++ b/haxe/ui/backend/AssetsImpl.hx
@@ -1,11 +1,11 @@
 package haxe.ui.backend;
 
+import hxd.res.Image;
 import haxe.io.Bytes;
 import haxe.ui.assets.FontInfo;
 import haxe.ui.assets.ImageInfo;
 import hxd.Res;
 import hxd.fs.BytesFileSystem.BytesFileEntry;
-import hxd.res.Image;
 
 class AssetsImpl extends AssetsBase { 
     public function embedFontSupported():Bool {


### PR DESCRIPTION
ImageInfo added to heaps recently in heaps (49fe167e3) inside hxd.res.Image. 
Moving the import to the start of file instead to allow haxe.ui.assets.ImageInfo to be used instead.