### PR TITLE
Don't use INDEX_OFFSET in _children.

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -152,7 +152,7 @@ class ComponentImpl extends ComponentBase {
     }
 
     private override function handleRemoveComponentAt(index:Int, dispose:Bool = true):Component {
-        var child = _children[index + INDEX_OFFSET];
+        var child = _children[index];
         if (child != null) {
             removeChild(child);
 


### PR DESCRIPTION
The way I'm reading [things](https://github.com/haxeui/haxeui-heaps/blob/88e78ec856a0cc000bd039f571730e52bcfe1ed9/haxe/ui/backend/ComponentImpl.hx#L24), the `INDEX_OFFSET` is meant for h2d's indices.

The offset causes a bug when removing elements by index. Minimal example:

```haxe
var app = new HaxeUIApp();

app.ready(function() {
	var root = new Component();
	Screen.instance.addComponent(root);
	var button = new Button();
	button.text = 'Zombie';
	root.addComponent(button);
	button.onClick = _ -> {
		root.removeComponentAt(0);
	}
	app.start();
});
```

Clicking on the button will not remove it. 

Interestingly, removing the button immediately after adding it causes the button not to render, even though `root.numChildren` yields `2`, which indicates it is still in the h2d display list (but maybe empty components bail out of rendering or something?).