### PR TITLE
fix crash when using styles + resizing the window

### DIFF
--- a/haxe/ui/backend/heaps/StyleHelper.hx
+++ b/haxe/ui/backend/heaps/StyleHelper.hx
@@ -15,6 +15,9 @@ class StyleHelper {
         }
 
         var container = c.getChildAt(0); // first child is always the style-objects container
+        if ( container == null ) {
+            return; // fix crash resizing the window; container doesn't exist yet
+        }
         
         w *= Toolkit.scaleX;
         h *= Toolkit.scaleY;


### PR DESCRIPTION
when resizing the window (on HashLink), I guess heaps or haxeui recreates a bunch of objects or something? and then this style helper is trying to touch the styles for containers that have been nulled, causing a crash?

so I just added this null check to fix it, works well for me at least!