### PR TITLE
let user type in TextField; fixed TextInputImpl

### DIFF
--- a/haxe/ui/backend/TextInputImpl.hx
+++ b/haxe/ui/backend/TextInputImpl.hx
@@ -1,8 +1,56 @@
 package haxe.ui.backend;
 
+import h2d.TextInput;
+
 class TextInputImpl extends TextDisplayImpl {
+
+    var textInput: TextInput;
+
     public function new() {
         super();
+    }
+
+    private override function createText() {
+        textInput = new TextInput(hxd.res.DefaultFont.get());
+        textInput.lineBreak = false;
+        textInput.onChange = onChange;
+        return textInput;
+    }
+
+    public override function focus() {
+        textInput.focus();
+    }
+
+    public override function blur() {
+        @:privateAccess textInput.interactive.blur();
+    }
+
+    private function onChange() {
+        _text = textInput.text;
+        _htmlText = textInput.text;
+        
+        measureText();
+        
+        if (_inputData.onChangedCallback != null) {
+            _inputData.onChangedCallback();
+        }
+    }
+
+    private override function validateStyle():Bool {
+        var measureTextRequired:Bool = super.validateStyle();
+
+        if ( _inputData.password) {
+            trace("TextInput password mode isn't supported in Heaps.");
+            _inputData.password = false; 
+        }
+
+        if (parentComponent.disabled) {
+            textInput.canEdit = false;
+        } else {
+            textInput.canEdit = true;
+        }
+        
+        return measureTextRequired;
     }
     
 }

--- a/haxe/ui/backend/TextInputImpl.hx
+++ b/haxe/ui/backend/TextInputImpl.hx
@@ -36,6 +36,12 @@ class TextInputImpl extends TextDisplayImpl {
         }
     }
 
+    private override function validateDisplay() {
+        super.validateDisplay();
+        
+        textInput.inputWidth = Math.round(textInput.maxWidth+4); // clip text input display to text component's width
+    }
+
     private override function validateStyle():Bool {
         var measureTextRequired:Bool = super.validateStyle();
 


### PR DESCRIPTION
problem: TextField not editable... because there's not actually any underlying h2d.TextInput there?

fix: modify TextInputImpl.hx to create a `h2d.TextInput` and hook up some focus / blur / onChange events, based on the tip from hoseyjoe in #20 

fixes #25 and #20 

I based some of my code patterns on https://github.com/haxeui/haxeui-openfl/blob/master/haxe/ui/backend/TextInputImpl.hx

known issues:
- password masking not supported by `h2d.TextInput` (added a warning message)
- vertical scrollable text area not supported by `h2d.TextInput` either, apparently (see https://github.com/HeapsIO/heaps/blob/master/h2d/TextInput.hx )