### PR TITLE
Store path when saving file via dialog

### DIFF
--- a/haxe/ui/backend/SaveFileDialogImpl.hx
+++ b/haxe/ui/backend/SaveFileDialogImpl.hx
@@ -27,7 +27,7 @@ class SaveFileDialogImpl extends SaveFileDialogBase {
             var file = hl.UI.saveFile(nativeOptions);
             hxd.System.allowTimeout = allowTimeout;
             if (file != null) {
-                var fullPath = file;
+                fullPath = file;
                 if (fileInfo.text != null) {
                     sys.io.File.saveContent(fullPath, fileInfo.text);
                 } else if (fileInfo.bytes != null) {


### PR DESCRIPTION
Updates Heaps backend to provide the path of a file saved via SaveFileDialog to the callback updated in [this haxeui-core PR.](https://github.com/haxeui/haxeui-core/pull/500)