### PR TITLE
Exclude git heaps from artifact search

### DIFF
--- a/classpath.exclusions
+++ b/classpath.exclusions
@@ -1,8 +1,6 @@
 ; exclude paths from classpath when searching for haxeui arifacts (module.xml, native.xml, etc)
 ; speeds up build
-\/h3d\/
-\/h2d\/
-\/hxd\/
+\/heaps\/
 \/hlopenal\/
 \/hlsdl\/
 


### PR DESCRIPTION
I believe the structure of git versions of heaps (`heaps/git/h2d/...`) is not allowing its inner packages to be excluded, or that this is just the wrong thing to have here in general. Replacing `h2d`, etc with `heaps` does exclude everything, including the samples directory. This shaves several hundred lines from `-D classpath_scan_verbose`.

Does this have consequences somewhere that I'm not aware of?