### PR TITLE
Mouse events are now cancelled and the components' event order has been fixed

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -695,6 +695,7 @@ class ComponentImpl extends ComponentBase {
                 mouseEvent.screenX = x;
                 mouseEvent.screenY = y;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
             return;
         }
@@ -716,6 +717,7 @@ class ComponentImpl extends ComponentBase {
                 mouseEvent.screenX = x;
                 mouseEvent.screenY = y;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
         }
         
@@ -728,6 +730,7 @@ class ComponentImpl extends ComponentBase {
                     mouseEvent.screenX = x;
                     mouseEvent.screenY = y;
                     fn(mouseEvent);
+                    event.canceled = mouseEvent.canceled;
                 }
             }
         } else if (i == false && _mouseOverFlag == true) {
@@ -739,6 +742,7 @@ class ComponentImpl extends ComponentBase {
                 mouseEvent.screenX = x;
                 mouseEvent.screenY = y;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
         }
     }    
@@ -777,6 +781,7 @@ class ComponentImpl extends ComponentBase {
                     mouseEvent.screenX = x;
                     mouseEvent.screenY = y;
                     fn(mouseEvent);
+                    event.canceled = mouseEvent.canceled;
                 }
             }
         }
@@ -807,6 +812,7 @@ class ComponentImpl extends ComponentBase {
                     mouseEvent.screenY = y;
                     Toolkit.callLater(function() {
                         fn(mouseEvent);
+                        event.canceled = mouseEvent.canceled;
                     });
                 }
                 
@@ -833,6 +839,7 @@ class ComponentImpl extends ComponentBase {
                 mouseEvent.screenX = x;
                 mouseEvent.screenY = y;
                 fn(mouseEvent);
+                event.canceled = mouseEvent.canceled;
             }
         } else {
             if (_mouseDownFlag) {
@@ -868,6 +875,7 @@ class ComponentImpl extends ComponentBase {
                     mouseEvent.screenX = x;
                     mouseEvent.screenY = y;
                     fn(mouseEvent);
+                    event.canceled = mouseEvent.canceled;
                 }
             }
         }
@@ -895,6 +903,7 @@ class ComponentImpl extends ComponentBase {
         mouseEvent.screenY = lastMouseY;
         mouseEvent.delta = Math.max(-1, Math.min(1, -delta));
         fn(mouseEvent);
+        event.canceled = mouseEvent.canceled;
     }
     
     //***********************************************************************************************************

--- a/haxe/ui/backend/heaps/MouseHelper.hx
+++ b/haxe/ui/backend/heaps/MouseHelper.hx
@@ -118,12 +118,17 @@ class MouseHelper {
         }
         
         list = list.copy();
+        list.reverse();
+
         var event = new MouseEvent(MouseEvent.MOUSE_MOVE);
         @:privateAccess event._originalEvent = e;
         event.screenX = e.relX / Toolkit.scaleX;
         event.screenY = e.relY / Toolkit.scaleY;
         for (l in list) {
             l(event);
+			if (event.canceled) {
+				break;
+			}
         }
     }
     
@@ -134,7 +139,8 @@ class MouseHelper {
         }
         
         list = list.copy();
-        
+        list.reverse();
+       
         var event = new MouseEvent(MouseEvent.MOUSE_DOWN);
         @:privateAccess event._originalEvent = e;
         event.screenX = e.relX / Toolkit.scaleX;
@@ -142,6 +148,9 @@ class MouseHelper {
         event.data = e.button;
         for (l in list) {
             l(event);
+			if (event.canceled) {
+				break;
+			}
         }
     }
     
@@ -152,6 +161,7 @@ class MouseHelper {
         }
         
         list = list.copy();
+		list.reverse();
         
         var event = new MouseEvent(MouseEvent.MOUSE_UP);
         @:privateAccess event._originalEvent = e;
@@ -160,6 +170,9 @@ class MouseHelper {
         event.data = e.button;
         for (l in list) {
             l(event);
+			if (event.canceled) {
+				break;
+			}
         }
     }
     
@@ -170,12 +183,16 @@ class MouseHelper {
         }
         
         list = list.copy();
+		list.reverse();
         
         var event = new MouseEvent(MouseEvent.MOUSE_WHEEL);
         @:privateAccess event._originalEvent = e;
         event.delta = e.wheelDelta;
         for (l in list) {
             l(event);
+			if (event.canceled) {
+				break;
+			}
         }
     }
 }


### PR DESCRIPTION
Currently, the order of components mouse event processing is "older first". It means that, if I scroll, the first component to ask for notification will be the first notified of the event, so, if I have children in a parent, the parent will be the first notified. If the event is cancelled when computed, it means only the parent will be computed.

The builder works the other way. The children are the first to be notified, allowing to scroll a scroll view inside a scroll view, for example.
Here is a builder : http://haxeui.org/builder/?e8c96d65
The child scroll view is scrolled but not the parent, because the event is cancelled when computed by the child.
For the buttons, the stepper value is 10 because the child is computed first but buttons don't cancel events, so the parent is computed afterward and it sets the stepper to 10.

Heaps is doing it in the opposite way : the stepper displays 30.
As for the scroll views, another issue is also present : the event cancellation is not present.

This PR adds the bubbling up of the cancellation of mouse events and the reversion of the order of event handling so children are processed first. I took inspiration from Flixel's backend code, although the latter doesn't reverse the list of callbacks. Either the order of callbacks is different or the ordering issue is present there.