### PR TITLE
Fixes right aligned labels,buttons. Input fields start better but sti…

### DIFF
--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -129,7 +129,9 @@ class TextDisplayImpl extends TextBase {
     private override function validateDisplay() {
         if (autoWidth == false) {
             sprite.maxWidth = _width != 0 ? _width : _textWidth;
-        } else if (sprite.textAlign == h2d.Text.Align.Center) {
+        }else if (sprite.textAlign == h2d.Text.Align.Right){
+            sprite.x =_width;
+        }else if (sprite.textAlign == h2d.Text.Align.Center) {
             sprite.x = (_left) + (_width / 2);
         }
     }

--- a/haxe/ui/backend/TextInputImpl.hx
+++ b/haxe/ui/backend/TextInputImpl.hx
@@ -29,9 +29,9 @@ class TextInputImpl extends TextDisplayImpl {
     // we're actually going to override this function so that it always returns
     // h2d.Text.Align.Left - this is because heaps text input doesnt seem to like
     // center aligned text (or right aligned), for now will simply turn it off
-    private override function getAlign(align:String):h2d.Text.Align {
+    /*private override function getAlign(align:String):h2d.Text.Align {
         return h2d.Text.Align.Left;
-    }
+    }*/
 
     public override function focus() {
         Toolkit.callLater(function() {


### PR DESCRIPTION
This allow labels/buttons to right align. Input fields are still ugly

Before
<img width="612" alt="{30E76A6B-3BB6-4987-B4FF-D365CD951456}" src="https://github.com/user-attachments/assets/a1d2f820-8315-4a09-8281-48f63b7c95de">


After
<img width="601" alt="{2DBD2278-D2FD-433B-A754-3134DFD3A921}" src="https://github.com/user-attachments/assets/1d80e499-7331-4eff-be3c-9301d6d38162">
